### PR TITLE
BitfieldSimplifier: arbitrary precision bit masks

### DIFF
--- a/include/klee/BitfieldSimplifier.h
+++ b/include/klee/BitfieldSimplifier.h
@@ -32,17 +32,18 @@
 
 #include "klee/Expr.h"
 #include "klee/util/ExprHashMap.h"
+#include "llvm/ADT/APInt.h"
 
 namespace klee {
 
 class BitfieldSimplifier {
 protected:
     struct BitsInfo {
-        uint64_t ignoredBits;   ///< Bits that can be ignored because they
-                                ///< are not used by higher-level expressions
-                                ///< (passed top-down)
-        uint64_t knownOneBits;  ///< Bits known to be one (passed bottom-up)
-        uint64_t knownZeroBits; ///< Bits known to be zero (passed bottom-up)
+        llvm::APInt ignoredBits;   ///< Bits that can be ignored because they
+                                   ///< are not used by higher-level expressions
+                                   ///< (passed top-down)
+        llvm::APInt knownOneBits;  ///< Bits known to be one (passed bottom-up)
+        llvm::APInt knownZeroBits; ///< Bits known to be zero (passed bottom-up)
     };
     typedef std::pair<ref<Expr>, BitsInfo> ExprBitsInfo;
 
@@ -51,14 +52,14 @@ protected:
 
     ExprHashMap<ExprBitsInfo> m_simplifiedExpressions;
 
-    ref<Expr> replaceWithConstant(ref<Expr> e, uint64_t value);
+    ref<Expr> replaceWithConstant(ref<Expr> e, const llvm::APInt& value);
 
-    ExprBitsInfo doSimplifyBits(ref<Expr> e, uint64_t ignoredBits);
+    ExprBitsInfo doSimplifyBits(ref<Expr> e, const llvm::APInt& ignoredBits);
 
 public:
     uint64_t m_cacheHits, m_cacheMisses;
 
-    ref<Expr> simplify(ref<Expr> e, uint64_t *knownZeroBits = NULL);
+    ref<Expr> simplify(ref<Expr> e, llvm::APInt *knownZeroBits = NULL);
 
     BitfieldSimplifier() {
         m_cacheHits = 0;

--- a/include/klee/Common.h
+++ b/include/klee/Common.h
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <unordered_set>
 
+#include "llvm/ADT/APInt.h"
+
 // XXX ugh
 namespace klee {
 class Solver;
@@ -74,6 +76,8 @@ struct hexval {
     hexval(uint64_t _value, int _width = 0) : value(_value), width(_width) {
     }
     hexval(void *_value, int _width = 0) : value((uint64_t) _value), width(_width) {
+    }
+    hexval(const llvm::APInt& _value) : value(_value.getLimitedValue()), width(_value.getBitWidth()) {
     }
 };
 

--- a/lib/Core/AddressSpace.cpp
+++ b/lib/Core/AddressSpace.cpp
@@ -188,13 +188,13 @@ bool AddressSpace::resolveOneFast(BitfieldSimplifier &simplifier, ref<Expr> addr
     }
 
     ref<Expr> offset = add->getRight();
-    uint64_t knownZeroBits;
+    llvm::APInt knownZeroBits;
     simplifier.simplify(offset, &knownZeroBits);
 
     uint64_t inBoundsSize;
     // Only handle 8-bits sized objects for now.
     // TODO: make it work for arbitrary consecutive numbers of 1s.
-    if ((knownZeroBits & ~(uint64_t) 0xff) == ~(uint64_t) 0xff) {
+    if ((knownZeroBits & ~llvm::APInt(64, 0xff)) == ~llvm::APInt(64, 0xff)) {
         inBoundsSize = 1 << 8;
     } else {
         return false;

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -148,7 +148,7 @@ static ref<Expr> SimplifyExtractLShr(const ref<Expr> &e) {
         return e;
     }
 
-    auto offset = shift->getZExtValue();
+    auto offset = shift->getLimitedValue();
     if (offset % 8) {
         return e;
     }


### PR DESCRIPTION
Use llvm::APInt instead of uint64_t for bit masks.
Needed for the modified (non-forking) helper for signed multiplication
which uses 128-bit integers.

Signed-off-by: Matteo Rizzo <matteo.rizzo@epfl.ch>